### PR TITLE
应该是一处判断错误导致始终无法使用util.Date

### DIFF
--- a/src/main/java/com/fengwenyi/codegenerator/generator/MyAutoGenerator.java
+++ b/src/main/java/com/fengwenyi/codegenerator/generator/MyAutoGenerator.java
@@ -54,7 +54,7 @@ public class MyAutoGenerator {
         }*/
 
         DateType dateType = DateType.TIME_PACK;
-        if (!"java.util".equalsIgnoreCase(bo.getDateTimeType())) {
+        if ("java.util".equalsIgnoreCase(bo.getDateTimeType())) {
             dateType = DateType.ONLY_DATE;
         }
         builder.dateType(dateType);


### PR DESCRIPTION
当页面选择使用java.util.Date时,CodeGeneratorBo#getDateTimeType为java.util, 
`if (!"java.util".equalsIgnoreCase(bo.getDateTimeType())) {
dateType = DateType.ONLY_DATE;
}`
这个判断将返回false,导致无法使用java.util.Date作为代码生成的日期类型